### PR TITLE
Fix wrong artist link in colophon

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -29,7 +29,7 @@
 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting">Stefanina Primicile Carafa, Marchioness of Cicerale and Duchess of Montejasi</i>,<br/>
 			a painting completed in 1875 by<br/>
-			<a href="https://en.wikipedia.org/wiki/Émile_Gaboriau">Edgar Degas</a>.<br/>
+			<a href="https://en.wikipedia.org/wiki/Edgar_Degas">Edgar Degas</a>.<br/>
 			The cover and title pages feature the<br/>
 			<b epub:type="se:name.visual-art.typeface">League Spartan</b> and <b epub:type="se:name.visual-art.typeface">Sorts Mill Goudy</b><br/>
 			typefaces created in 2014 and 2009 by<br/>


### PR DESCRIPTION
It looked like the artist wiki link in the  colophon was to the author, not to the artist, Edgar Degas.